### PR TITLE
Values input overrides

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master, main ]
 
 env:
-  TERRAFORM_DOCS_VERSION: "v0.11.2"
+  TERRAFORM_DOCS_VERSION: "v0.15.0"
   TFLINT_VERSION: "v0.25.0"
   TFSEC_VERSION: "v0.39.6"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
 #    - id: terraform_tfsec
     - id: terraform_docs
       args:
-        - '--args=--hide providers --sort-by-required'
+        - '--args=--hide providers --sort-by required'
 
   - repo: git://github.com/pecigonzalo/pre-commit-terraform-vars
     rev: v1.0.0

--- a/README.md
+++ b/README.md
@@ -35,54 +35,58 @@ See [Basic example](examples/basic/README.md) for further information.
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13 |
-| aws | >= 2.0 |
-| helm | >= 1.0 |
-| kubernetes | >= 1.10 |
-| local | >= 1.3 |
-| null | >= 2.0 |
-| time | >= 0.6 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 1.0 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.6 |
+| <a name="requirement_utils"></a> [utils](#requirement\_utils) | >= 0.12.0 |
 
 ## Modules
 
-No Modules.
+No modules.
 
 ## Resources
 
-| Name |
-|------|
-| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) |
-| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) |
-| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) |
-| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) |
-| [aws_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) |
-| [helm_release](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) |
-| [time_sleep](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) |
+| Name | Type |
+|------|------|
+| [aws_iam_policy.cert_manager](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.cert_manager](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.cert_manager](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [helm_release.cert_manager](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [helm_release.cert_manager_default_cluster_issuer](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [helm_release.default_cluster_issuer](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [time_sleep.default_cluster_issuer](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
+| [aws_iam_policy_document.cert_manager](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.cert_manager_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.cert_manager_irsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [utils_deep_merge_yaml.values_cert_manager](https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml) | data source |
+| [utils_deep_merge_yaml.values_cert_manager_issuer](https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| cluster\_identity\_oidc\_issuer | The OIDC Identity issuer for the cluster | `string` | n/a | yes |
-| cluster\_identity\_oidc\_issuer\_arn | The OIDC Identity issuer ARN for the cluster that can be used to associate IAM roles with a service account | `string` | n/a | yes |
-| cluster\_name | The name of the cluster | `string` | n/a | yes |
-| cluster\_issuer\_enabled | Variable indicating whether default ClusterIssuer CRD is enabled | `bool` | `false` | no |
-| cluster\_issuer\_settings | Additional settings which will be passed to the Helm chart cluster\_issuer values, see https://github.com/lablabs/terraform-aws-eks-aws-cert-manager/blob/master/helm/defaultClusterIssuer/values.yaml | `map(any)` | `{}` | no |
-| enabled | Variable indicating whether deployment is enabled | `bool` | `true` | no |
-| helm\_chart\_name | Helm chart name to be installed | `string` | `"cert-manager"` | no |
-| helm\_chart\_version | Version of the Helm chart | `string` | `"v1.2.0"` | no |
-| helm\_release\_name | Helm release name | `string` | `"cert-manager"` | no |
-| helm\_repo\_url | Helm repository | `string` | `"https://charts.jetstack.io"` | no |
-| k8s\_create\_namespace | Whether to create k8s namespace with name defined by `k8s_namespace` | `bool` | `false` | no |
-| k8s\_namespace | The k8s namespace in which the cert-manager service account has been created | `string` | `"kube-system"` | no |
-| k8s\_service\_account\_name | The k8s cert-manager service account name | `string` | `"cert-manager"` | no |
-| mod\_dependency | Dependence variable binds all AWS resources allocated by this module, dependent modules reference this variable | `any` | `null` | no |
-| policy\_allowed\_zone\_ids | List of the Route53 zone ids for service account IAM role access | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
-| settings | Additional settings which will be passed to the Helm chart values, see https://artifacthub.io/packages/helm/jetstack/cert-manager | `map(any)` | `{}` | no |
+| <a name="input_cluster_identity_oidc_issuer"></a> [cluster\_identity\_oidc\_issuer](#input\_cluster\_identity\_oidc\_issuer) | The OIDC Identity issuer for the cluster | `string` | n/a | yes |
+| <a name="input_cluster_identity_oidc_issuer_arn"></a> [cluster\_identity\_oidc\_issuer\_arn](#input\_cluster\_identity\_oidc\_issuer\_arn) | The OIDC Identity issuer ARN for the cluster that can be used to associate IAM roles with a service account | `string` | n/a | yes |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of the cluster | `string` | n/a | yes |
+| <a name="input_cluster_issuer_enabled"></a> [cluster\_issuer\_enabled](#input\_cluster\_issuer\_enabled) | Variable indicating whether default ClusterIssuer CRD is enabled | `bool` | `false` | no |
+| <a name="input_cluster_issuer_settings"></a> [cluster\_issuer\_settings](#input\_cluster\_issuer\_settings) | Additional settings which will be passed to the Helm chart cluster\_issuer values, see https://github.com/lablabs/terraform-aws-eks-aws-cert-manager/blob/master/helm/defaultClusterIssuer/values.yaml | `map(any)` | `{}` | no |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Variable indicating whether deployment is enabled | `bool` | `true` | no |
+| <a name="input_helm_chart_name"></a> [helm\_chart\_name](#input\_helm\_chart\_name) | Helm chart name to be installed | `string` | `"cert-manager"` | no |
+| <a name="input_helm_chart_version"></a> [helm\_chart\_version](#input\_helm\_chart\_version) | Version of the Helm chart | `string` | `"v1.2.0"` | no |
+| <a name="input_helm_release_name"></a> [helm\_release\_name](#input\_helm\_release\_name) | Helm release name | `string` | `"cert-manager"` | no |
+| <a name="input_helm_repo_url"></a> [helm\_repo\_url](#input\_helm\_repo\_url) | Helm repository | `string` | `"https://charts.jetstack.io"` | no |
+| <a name="input_k8s_create_namespace"></a> [k8s\_create\_namespace](#input\_k8s\_create\_namespace) | Whether to create k8s namespace with name defined by `k8s_namespace` | `bool` | `false` | no |
+| <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | The k8s namespace in which the cert-manager service account has been created | `string` | `"kube-system"` | no |
+| <a name="input_k8s_service_account_name"></a> [k8s\_service\_account\_name](#input\_k8s\_service\_account\_name) | The k8s cert-manager service account name | `string` | `"cert-manager"` | no |
+| <a name="input_policy_allowed_zone_ids"></a> [policy\_allowed\_zone\_ids](#input\_policy\_allowed\_zone\_ids) | List of the Route53 zone ids for service account IAM role access | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
+| <a name="input_settings"></a> [settings](#input\_settings) | Additional settings which will be passed to the Helm chart values, see https://artifacthub.io/packages/helm/jetstack/cert-manager | `map(any)` | `{}` | no |
+| <a name="input_values"></a> [values](#input\_values) | Additional values. Values will be merged, in order, as Helm does with multiple -f options | `string` | `""` | no |
 
 ## Outputs
 
-No output.
+No outputs.
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Contributing and reporting issues

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ No modules.
 | <a name="input_cluster_issuer_settings"></a> [cluster\_issuer\_settings](#input\_cluster\_issuer\_settings) | Additional settings which will be passed to the Helm chart cluster\_issuer values, see https://github.com/lablabs/terraform-aws-eks-aws-cert-manager/blob/master/helm/defaultClusterIssuer/values.yaml | `map(any)` | `{}` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Variable indicating whether deployment is enabled | `bool` | `true` | no |
 | <a name="input_helm_chart_name"></a> [helm\_chart\_name](#input\_helm\_chart\_name) | Helm chart name to be installed | `string` | `"cert-manager"` | no |
-| <a name="input_helm_chart_version"></a> [helm\_chart\_version](#input\_helm\_chart\_version) | Version of the Helm chart | `string` | `"v1.2.0"` | no |
+| <a name="input_helm_chart_version"></a> [helm\_chart\_version](#input\_helm\_chart\_version) | Version of the Helm chart | `string` | `"1.5.3"` | no |
 | <a name="input_helm_release_name"></a> [helm\_release\_name](#input\_helm\_release\_name) | Helm release name | `string` | `"cert-manager"` | no |
 | <a name="input_helm_repo_url"></a> [helm\_repo\_url](#input\_helm\_repo\_url) | Helm repository | `string` | `"https://charts.jetstack.io"` | no |
 | <a name="input_k8s_create_namespace"></a> [k8s\_create\_namespace](#input\_k8s\_create\_namespace) | Whether to create k8s namespace with name defined by `k8s_namespace` | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ No modules.
 | [aws_iam_policy_document.cert_manager_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cert_manager_irsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [utils_deep_merge_yaml.default_cluster_issuer_values](https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml) | data source |
 | [utils_deep_merge_yaml.values](https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml) | data source |
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -53,14 +53,12 @@ No modules.
 | [aws_iam_role.cert_manager](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.cert_manager](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [helm_release.cert_manager](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
-| [helm_release.cert_manager_default_cluster_issuer](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.default_cluster_issuer](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [time_sleep.default_cluster_issuer](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [aws_iam_policy_document.cert_manager](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cert_manager_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cert_manager_irsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
-| [utils_deep_merge_yaml.cluster_issuers_values](https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml) | data source |
 | [utils_deep_merge_yaml.values](https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml) | data source |
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ No modules.
 | [aws_iam_policy_document.cert_manager_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cert_manager_irsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
-| [utils_deep_merge_yaml.values_cert_manager](https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml) | data source |
-| [utils_deep_merge_yaml.values_cert_manager_cluster_issuers](https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml) | data source |
+| [utils_deep_merge_yaml.cluster_issuers_values](https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml) | data source |
+| [utils_deep_merge_yaml.values](https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml) | data source |
 
 ## Inputs
 
@@ -72,18 +72,22 @@ No modules.
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of the cluster | `string` | n/a | yes |
 | <a name="input_cluster_issuer_enabled"></a> [cluster\_issuer\_enabled](#input\_cluster\_issuer\_enabled) | Variable indicating whether default ClusterIssuer CRD is enabled | `bool` | `false` | no |
 | <a name="input_cluster_issuer_settings"></a> [cluster\_issuer\_settings](#input\_cluster\_issuer\_settings) | Additional settings which will be passed to the Helm chart cluster\_issuer values, see https://github.com/lablabs/terraform-aws-eks-aws-cert-manager/blob/master/helm/defaultClusterIssuer/values.yaml | `map(any)` | `{}` | no |
+| <a name="input_cluster_issuers_values"></a> [cluster\_issuers\_values](#input\_cluster\_issuers\_values) | Additional values for cert manager cluster issuers helm chart. Values will be merged, in order, as Helm does with multiple -f options | `string` | `""` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Variable indicating whether deployment is enabled | `bool` | `true` | no |
 | <a name="input_helm_chart_name"></a> [helm\_chart\_name](#input\_helm\_chart\_name) | Helm chart name to be installed | `string` | `"cert-manager"` | no |
 | <a name="input_helm_chart_version"></a> [helm\_chart\_version](#input\_helm\_chart\_version) | Version of the Helm chart | `string` | `"1.5.3"` | no |
+| <a name="input_helm_create_namespace"></a> [helm\_create\_namespace](#input\_helm\_create\_namespace) | Whether to create k8s namespace with name defined by `k8s_namespace` | `bool` | `true` | no |
 | <a name="input_helm_release_name"></a> [helm\_release\_name](#input\_helm\_release\_name) | Helm release name | `string` | `"cert-manager"` | no |
 | <a name="input_helm_repo_url"></a> [helm\_repo\_url](#input\_helm\_repo\_url) | Helm repository | `string` | `"https://charts.jetstack.io"` | no |
-| <a name="input_k8s_create_namespace"></a> [k8s\_create\_namespace](#input\_k8s\_create\_namespace) | Whether to create k8s namespace with name defined by `k8s_namespace` | `bool` | `false` | no |
-| <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | The k8s namespace in which the cert-manager service account has been created | `string` | `"kube-system"` | no |
+| <a name="input_k8s_assume_role_arn"></a> [k8s\_assume\_role\_arn](#input\_k8s\_assume\_role\_arn) | Whether to create and use default role or assume existing role. Useful for hosted zones in another AWS account. Default (empty string) use default role. | `string` | `""` | no |
+| <a name="input_k8s_irsa_role_create"></a> [k8s\_irsa\_role\_create](#input\_k8s\_irsa\_role\_create) | Whether to create IRSA role and annotate service account | `bool` | `true` | no |
+| <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | The K8s namespace in which the external-dns will be installed | `string` | `"kube-system"` | no |
+| <a name="input_k8s_rbac_create"></a> [k8s\_rbac\_create](#input\_k8s\_rbac\_create) | Whether to create and use RBAC resources | `bool` | `true` | no |
+| <a name="input_k8s_service_account_create"></a> [k8s\_service\_account\_create](#input\_k8s\_service\_account\_create) | Whether to create Service Account | `bool` | `true` | no |
 | <a name="input_k8s_service_account_name"></a> [k8s\_service\_account\_name](#input\_k8s\_service\_account\_name) | The k8s cert-manager service account name | `string` | `"cert-manager"` | no |
 | <a name="input_policy_allowed_zone_ids"></a> [policy\_allowed\_zone\_ids](#input\_policy\_allowed\_zone\_ids) | List of the Route53 zone ids for service account IAM role access | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
-| <a name="input_settings"></a> [settings](#input\_settings) | Additional settings which will be passed to the Helm chart values, see https://artifacthub.io/packages/helm/jetstack/cert-manager | `map(any)` | `{}` | no |
-| <a name="input_values_cert_manager"></a> [values\_cert\_manager](#input\_values\_cert\_manager) | Additional values for cert manager helm chart. Values will be merged, in order, as Helm does with multiple -f options | `string` | `""` | no |
-| <a name="input_values_cluster_issuers"></a> [values\_cluster\_issuers](#input\_values\_cluster\_issuers) | Additional values for cert manager cluster issuers helm chart. Values will be merged, in order, as Helm does with multiple -f options | `string` | `""` | no |
+| <a name="input_settings"></a> [settings](#input\_settings) | Additional settings which will be passed to the Helm chart values, see https://artifacthub.io/packages/helm/cert-manager/cert-manager | `map(any)` | `{}` | no |
+| <a name="input_values"></a> [values](#input\_values) | Additional values for cert manager helm chart. Values will be merged, in order, as Helm does with multiple -f options | `string` | `""` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ No modules.
 | [aws_iam_policy_document.cert_manager_irsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [utils_deep_merge_yaml.values_cert_manager](https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml) | data source |
-| [utils_deep_merge_yaml.values_cert_manager_issuer](https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml) | data source |
+| [utils_deep_merge_yaml.values_cert_manager_cluster_issuers](https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml) | data source |
 
 ## Inputs
 
@@ -82,7 +82,8 @@ No modules.
 | <a name="input_k8s_service_account_name"></a> [k8s\_service\_account\_name](#input\_k8s\_service\_account\_name) | The k8s cert-manager service account name | `string` | `"cert-manager"` | no |
 | <a name="input_policy_allowed_zone_ids"></a> [policy\_allowed\_zone\_ids](#input\_policy\_allowed\_zone\_ids) | List of the Route53 zone ids for service account IAM role access | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
 | <a name="input_settings"></a> [settings](#input\_settings) | Additional settings which will be passed to the Helm chart values, see https://artifacthub.io/packages/helm/jetstack/cert-manager | `map(any)` | `{}` | no |
-| <a name="input_values"></a> [values](#input\_values) | Additional values. Values will be merged, in order, as Helm does with multiple -f options | `string` | `""` | no |
+| <a name="input_values_cert_manager"></a> [values\_cert\_manager](#input\_values\_cert\_manager) | Additional values for cert manager helm chart. Values will be merged, in order, as Helm does with multiple -f options | `string` | `""` | no |
+| <a name="input_values_cluster_issuers"></a> [values\_cluster\_issuers](#input\_values\_cluster\_issuers) | Additional values for cert manager cluster issuers helm chart. Values will be merged, in order, as Helm does with multiple -f options | `string` | `""` | no |
 
 ## Outputs
 

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -12,9 +12,9 @@ No requirements.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_cert-manager"></a> [cert-manager](#module\_cert-manager) | ../../ | n/a |
-| <a name="module_eks_cluster"></a> [eks\_cluster](#module\_eks\_cluster) | cloudposse/eks-cluster/aws | n/a |
-| <a name="module_eks_workers"></a> [eks\_workers](#module\_eks\_workers) | cloudposse/eks-workers/aws | n/a |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | n/a |
+| <a name="module_eks_cluster"></a> [eks\_cluster](#module\_eks\_cluster) | cloudposse/eks-cluster/aws | 0.43.2 |
+| <a name="module_eks_node_group"></a> [eks\_node\_group](#module\_eks\_node\_group) | cloudposse/eks-node-group/aws | 0.25.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 3.6.0 |
 
 ## Resources
 

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -11,23 +11,23 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| cert-manager | ../../ |  |
-| eks_cluster | cloudposse/eks-cluster/aws |  |
-| eks_workers | cloudposse/eks-workers/aws |  |
-| vpc | terraform-aws-modules/vpc/aws |  |
+| <a name="module_cert-manager"></a> [cert-manager](#module\_cert-manager) | ../../ | n/a |
+| <a name="module_eks_cluster"></a> [eks\_cluster](#module\_eks\_cluster) | cloudposse/eks-cluster/aws | n/a |
+| <a name="module_eks_workers"></a> [eks\_workers](#module\_eks\_workers) | cloudposse/eks-workers/aws | n/a |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | n/a |
 
 ## Resources
 
-| Name |
-|------|
-| [aws_eks_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) |
-| [aws_eks_cluster_auth](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) |
+| Name | Type |
+|------|------|
+| [aws_eks_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
+| [aws_eks_cluster_auth.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) | data source |
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
-No output.
+No outputs.
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -1,7 +1,7 @@
 module "vpc" {
   source = "terraform-aws-modules/vpc/aws"
 
-  name               = "cluster-autoscaler-vpc"
+  name               = "cert-manager-vpc"
   cidr               = "10.0.0.0/16"
   azs                = ["eu-central-1a", "eu-central-1b"]
   public_subnets     = ["10.0.101.0/24", "10.0.102.0/24"]
@@ -14,7 +14,7 @@ module "eks_cluster" {
   region     = "eu-central-1"
   subnet_ids = module.vpc.public_subnets
   vpc_id     = module.vpc.vpc_id
-  name       = "cluster-autoscaler"
+  name       = "cert-manager"
 
   workers_security_group_ids = [module.eks_workers.security_group_id]
   workers_role_arns          = [module.eks_workers.workers_role_arn]
@@ -25,8 +25,7 @@ module "eks_workers" {
 
   cluster_certificate_authority_data = module.eks_cluster.eks_cluster_certificate_authority_data
   cluster_endpoint                   = module.eks_cluster.eks_cluster_endpoint
-  cluster_name                       = module.eks_cluster.eks_cluster_id
-  cluster_security_group_id          = module.eks_cluster.security_group_id
+  cluster_name                       = "cert-manager"
   instance_type                      = "t3.medium"
   max_size                           = 1
   min_size                           = 1

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -1,5 +1,6 @@
 module "vpc" {
-  source = "terraform-aws-modules/vpc/aws"
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "3.6.0"
 
   name               = "cert-manager-vpc"
   cidr               = "10.0.0.0/16"
@@ -9,33 +10,27 @@ module "vpc" {
 }
 
 module "eks_cluster" {
-  source = "cloudposse/eks-cluster/aws"
+  source  = "cloudposse/eks-cluster/aws"
+  version = "0.43.2"
 
   region     = "eu-central-1"
   subnet_ids = module.vpc.public_subnets
   vpc_id     = module.vpc.vpc_id
   name       = "cert-manager"
-
-  workers_security_group_ids = [module.eks_workers.security_group_id]
-  workers_role_arns          = [module.eks_workers.workers_role_arn]
 }
 
-module "eks_workers" {
-  source = "cloudposse/eks-workers/aws"
+module "eks_node_group" {
+  source  = "cloudposse/eks-node-group/aws"
+  version = "0.25.0"
 
-  cluster_certificate_authority_data = module.eks_cluster.eks_cluster_certificate_authority_data
-  cluster_endpoint                   = module.eks_cluster.eks_cluster_endpoint
-  cluster_name                       = "cert-manager"
-  instance_type                      = "t3.medium"
-  max_size                           = 1
-  min_size                           = 1
-  subnet_ids                         = module.vpc.public_subnets
-  vpc_id                             = module.vpc.vpc_id
-
-  associate_public_ip_address = true
+  cluster_name   = "cert-manager"
+  instance_types = ["t3.medium"]
+  subnet_ids     = module.vpc.public_subnets
+  min_size       = 1
+  desired_size   = 1
+  max_size       = 2
+  depends_on     = [module.eks_cluster.kubernetes_config_map_id]
 }
-
-# Use the module:
 
 module "cert-manager" {
   source = "../../"

--- a/examples/basic/providers.tf
+++ b/examples/basic/providers.tf
@@ -10,12 +10,6 @@ data "aws_eks_cluster_auth" "this" {
   name = module.eks_cluster.eks_cluster_id
 }
 
-provider "kubernetes" {
-  host                   = data.aws_eks_cluster.this.endpoint
-  cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority.0.data)
-  token                  = data.aws_eks_cluster_auth.this.token
-}
-
 provider "helm" {
   kubernetes {
     host                   = data.aws_eks_cluster.this.endpoint

--- a/helm/defaultClusterIssuer/values.yaml
+++ b/helm/defaultClusterIssuer/values.yaml
@@ -9,7 +9,7 @@ route53:
     email: user@example.com
     privateKeySecretRef:
       name: cluster-issuer-secret
-  region: "eu-west-1"
+  region: "eu-central-1"
   #hostedZoneID: DIKER8JEXAMPLE # optional, see policy above
   #roleArn: arn:aws:iam::YYYYYYYYYYYY:role/dns-manager
   dnsZones:

--- a/helm/defaultClusterIssuer/values.yaml
+++ b/helm/defaultClusterIssuer/values.yaml
@@ -5,8 +5,8 @@ route53:
   enabled: true
   name: "default"
   acme:
-    server: https://acme-staging-v02.api.letsencrypt.org/directory
-    email: user@example.com
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: default@example.com
     privateKeySecretRef:
       name: cluster-issuer-secret
   region: "eu-central-1"

--- a/iam.tf
+++ b/iam.tf
@@ -57,7 +57,7 @@ data "aws_iam_policy_document" "cert_manager_assume" {
     ]
 
     resources = [
-      var.cluster_issuer_settings["route53.roleArn"]
+      var.k8s_assume_role_arn
     ]
   }
 }

--- a/iam.tf
+++ b/iam.tf
@@ -1,13 +1,9 @@
-# aws.assumeRoleArn
-
 locals {
-  assume_role = length(try(var.cluster_issuer_settings["route53.roleArn"], "")) > 0 ? true : false
+  assume_role = length(var.k8s_assume_role_arn) > 0 ? true : false
 }
 
-### iam ###
-# Policy
 data "aws_iam_policy_document" "cert_manager" {
-  count = var.enabled && !local.assume_role ? 1 : 0
+  count = local.k8s_irsa_role_create && !local.assume_role ? 1 : 0
 
   statement {
     sid = "ChangeResourceRecordSets"
@@ -49,7 +45,7 @@ data "aws_iam_policy_document" "cert_manager" {
 }
 
 data "aws_iam_policy_document" "cert_manager_assume" {
-  count = var.enabled && local.assume_role ? 1 : 0
+  count = local.k8s_irsa_role_create && local.assume_role ? 1 : 0
 
   statement {
     sid = "AllowAssumeCertManagerRole"
@@ -68,7 +64,7 @@ data "aws_iam_policy_document" "cert_manager_assume" {
 
 
 resource "aws_iam_policy" "cert_manager" {
-  count = var.enabled ? 1 : 0
+  count = local.k8s_irsa_role_create ? 1 : 0
 
   name        = "${var.cluster_name}-cert-manager"
   path        = "/"
@@ -79,7 +75,7 @@ resource "aws_iam_policy" "cert_manager" {
 
 # Role
 data "aws_iam_policy_document" "cert_manager_irsa" {
-  count = var.enabled ? 1 : 0
+  count = local.k8s_irsa_role_create ? 1 : 0
 
   statement {
     actions = ["sts:AssumeRoleWithWebIdentity"]
@@ -103,14 +99,14 @@ data "aws_iam_policy_document" "cert_manager_irsa" {
 }
 
 resource "aws_iam_role" "cert_manager" {
-  count = var.enabled ? 1 : 0
+  count = local.k8s_irsa_role_create ? 1 : 0
 
   name               = "${var.cluster_name}-cert-manager"
   assume_role_policy = data.aws_iam_policy_document.cert_manager_irsa[0].json
 }
 
 resource "aws_iam_role_policy_attachment" "cert_manager" {
-  count = var.enabled ? 1 : 0
+  count = local.k8s_irsa_role_create ? 1 : 0
 
   role       = aws_iam_role.cert_manager[0].name
   policy_arn = aws_iam_policy.cert_manager[0].arn

--- a/iam.tf
+++ b/iam.tf
@@ -75,8 +75,6 @@ resource "aws_iam_policy" "cert_manager" {
   description = "Policy for cert-manager service"
 
   policy = local.assume_role ? data.aws_iam_policy_document.cert_manager_assume[0].json : data.aws_iam_policy_document.cert_manager[0].json
-
-  depends_on = [var.mod_dependency]
 }
 
 # Role
@@ -109,8 +107,6 @@ resource "aws_iam_role" "cert_manager" {
 
   name               = "${var.cluster_name}-cert-manager"
   assume_role_policy = data.aws_iam_policy_document.cert_manager_irsa[0].json
-
-  depends_on = [var.mod_dependency]
 }
 
 resource "aws_iam_role_policy_attachment" "cert_manager" {
@@ -118,6 +114,4 @@ resource "aws_iam_role_policy_attachment" "cert_manager" {
 
   role       = aws_iam_role.cert_manager[0].name
   policy_arn = aws_iam_policy.cert_manager[0].arn
-
-  depends_on = [var.mod_dependency]
 }

--- a/iam.tf
+++ b/iam.tf
@@ -62,7 +62,6 @@ data "aws_iam_policy_document" "cert_manager_assume" {
   }
 }
 
-
 resource "aws_iam_policy" "cert_manager" {
   count = local.k8s_irsa_role_create ? 1 : 0
 
@@ -73,7 +72,6 @@ resource "aws_iam_policy" "cert_manager" {
   policy = local.assume_role ? data.aws_iam_policy_document.cert_manager_assume[0].json : data.aws_iam_policy_document.cert_manager[0].json
 }
 
-# Role
 data "aws_iam_policy_document" "cert_manager_irsa" {
   count = local.k8s_irsa_role_create ? 1 : 0
 

--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,7 @@ data "utils_deep_merge_yaml" "values_cert_manager_cluster_issuers" {
   count = var.enabled ? 1 : 0
   input = compact([
     local.values_cert_manager_cluster_issuers,
-    var.values_cert_manager_cluster_issuers
+    var.values_cluster_issuers
   ])
 }
 

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ locals {
     }
   })
 
-  values_cert_manager_issuer = yamlencode({
+  values_cert_manager_cluster_issuers = yamlencode({
     "installCRDs" : true
     "serviceAccount" : {
       "name" : var.k8s_service_account_name
@@ -29,15 +29,15 @@ data "utils_deep_merge_yaml" "values_cert_manager" {
   count = var.enabled ? 1 : 0
   input = compact([
     local.values_cert_manager,
-    var.values
+    var.values_cert_manager
   ])
 }
 
-data "utils_deep_merge_yaml" "values_cert_manager_issuer" {
+data "utils_deep_merge_yaml" "values_cert_manager_cluster_issuers" {
   count = var.enabled ? 1 : 0
   input = compact([
-    local.values_cert_manager_issuer,
-    var.values
+    local.values_cert_manager_cluster_issuers,
+    var.values_cert_manager_cluster_issuers
   ])
 }
 
@@ -78,7 +78,7 @@ resource "helm_release" "cert_manager_default_cluster_issuer" {
   wait             = true
 
   values = [
-    data.utils_deep_merge_yaml.values_cert_manager_issuer[0].output
+    data.utils_deep_merge_yaml.values_cert_manager_cluster_issuers[0].output
   ]
 
   dynamic "set" {

--- a/variables.tf
+++ b/variables.tf
@@ -62,10 +62,16 @@ variable "helm_repo_url" {
   description = "Helm repository"
 }
 
-variable "values" {
+variable "values_cert_manager" {
   type        = string
   default     = ""
-  description = "Additional values. Values will be merged, in order, as Helm does with multiple -f options"
+  description = "Additional values for cert manager helm chart. Values will be merged, in order, as Helm does with multiple -f options"
+}
+
+variable "values_cluster_issuers" {
+  type        = string
+  default     = ""
+  description = "Additional values for cert manager cluster issuers helm chart. Values will be merged, in order, as Helm does with multiple -f options"
 }
 
 # K8S

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,14 @@
-# Required module inputs
+variable "enabled" {
+  type        = bool
+  default     = true
+  description = "Variable indicating whether deployment is enabled"
+}
+
+variable "cluster_issuer_enabled" {
+  type        = bool
+  default     = false
+  description = "Variable indicating whether default ClusterIssuer CRD is enabled"
+}
 
 variable "cluster_name" {
   type        = string
@@ -14,29 +24,6 @@ variable "cluster_identity_oidc_issuer_arn" {
   type        = string
   description = "The OIDC Identity issuer ARN for the cluster that can be used to associate IAM roles with a service account"
 }
-
-variable "policy_allowed_zone_ids" {
-  type        = list(string)
-  default     = ["*"]
-  description = "List of the Route53 zone ids for service account IAM role access"
-}
-
-# cert-manager
-
-variable "enabled" {
-  type        = bool
-  default     = true
-  description = "Variable indicating whether deployment is enabled"
-}
-
-variable "cluster_issuer_enabled" {
-  type        = bool
-  default     = false
-  description = "Variable indicating whether default ClusterIssuer CRD is enabled"
-}
-
-
-# Helm
 
 variable "helm_chart_name" {
   type        = string
@@ -62,30 +49,39 @@ variable "helm_repo_url" {
   description = "Helm repository"
 }
 
-variable "values_cert_manager" {
-  type        = string
-  default     = ""
-  description = "Additional values for cert manager helm chart. Values will be merged, in order, as Helm does with multiple -f options"
-}
-
-variable "values_cluster_issuers" {
-  type        = string
-  default     = ""
-  description = "Additional values for cert manager cluster issuers helm chart. Values will be merged, in order, as Helm does with multiple -f options"
-}
-
-# K8S
-
-variable "k8s_create_namespace" {
+variable "helm_create_namespace" {
   type        = bool
-  default     = false
+  default     = true
   description = "Whether to create k8s namespace with name defined by `k8s_namespace`"
 }
 
 variable "k8s_namespace" {
   type        = string
   default     = "kube-system"
-  description = "The k8s namespace in which the cert-manager service account has been created"
+  description = "The K8s namespace in which the external-dns will be installed"
+}
+
+variable "k8s_rbac_create" {
+  type        = bool
+  default     = true
+  description = "Whether to create and use RBAC resources"
+}
+
+variable "k8s_service_account_create" {
+  type        = bool
+  default     = true
+  description = "Whether to create Service Account"
+}
+
+variable "k8s_irsa_role_create" {
+  type        = bool
+  default     = true
+  description = "Whether to create IRSA role and annotate service account"
+}
+
+variable "k8s_assume_role_arn" {
+  default     = ""
+  description = "Whether to create and use default role or assume existing role. Useful for hosted zones in another AWS account. Default (empty string) use default role."
 }
 
 variable "k8s_service_account_name" {
@@ -97,11 +93,29 @@ variable "k8s_service_account_name" {
 variable "settings" {
   type        = map(any)
   default     = {}
-  description = "Additional settings which will be passed to the Helm chart values, see https://artifacthub.io/packages/helm/jetstack/cert-manager"
+  description = "Additional settings which will be passed to the Helm chart values, see https://artifacthub.io/packages/helm/cert-manager/cert-manager"
 }
 
 variable "cluster_issuer_settings" {
   type        = map(any)
   default     = {}
   description = "Additional settings which will be passed to the Helm chart cluster_issuer values, see https://github.com/lablabs/terraform-aws-eks-aws-cert-manager/blob/master/helm/defaultClusterIssuer/values.yaml"
+}
+
+variable "values" {
+  type        = string
+  default     = ""
+  description = "Additional values for cert manager helm chart. Values will be merged, in order, as Helm does with multiple -f options"
+}
+
+variable "cluster_issuers_values" {
+  type        = string
+  default     = ""
+  description = "Additional values for cert manager cluster issuers helm chart. Values will be merged, in order, as Helm does with multiple -f options"
+}
+
+variable "policy_allowed_zone_ids" {
+  type        = list(string)
+  default     = ["*"]
+  description = "List of the Route53 zone ids for service account IAM role access"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -46,7 +46,7 @@ variable "helm_chart_name" {
 
 variable "helm_chart_version" {
   type        = string
-  default     = "v1.2.0"
+  default     = "1.5.3"
   description = "Version of the Helm chart"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -62,6 +62,12 @@ variable "helm_repo_url" {
   description = "Helm repository"
 }
 
+variable "values" {
+  type        = string
+  default     = ""
+  description = "Additional values. Values will be merged, in order, as Helm does with multiple -f options"
+}
+
 # K8S
 
 variable "k8s_create_namespace" {
@@ -80,11 +86,6 @@ variable "k8s_service_account_name" {
   type        = string
   default     = "cert-manager"
   description = "The k8s cert-manager service account name"
-}
-
-variable "mod_dependency" {
-  default     = null
-  description = "Dependence variable binds all AWS resources allocated by this module, dependent modules reference this variable"
 }
 
 variable "settings" {

--- a/versions.tf
+++ b/versions.tf
@@ -10,22 +10,25 @@ terraform {
       source  = "hashicorp/helm"
       version = ">= 1.0"
     }
-    null = {
-      source  = "hashicorp/null"
-      version = ">= 2.0"
-    }
-    local = {
-      source  = "hashicorp/local"
-      version = ">= 1.3"
-    }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 1.10"
-    }
+    # null = {
+    #   source  = "hashicorp/null"
+    #   version = ">= 2.0"
+    # }
+    # local = {
+    #   source  = "hashicorp/local"
+    #   version = ">= 1.3"
+    # }
+    # kubernetes = {
+    #   source  = "hashicorp/kubernetes"
+    #   version = ">= 1.10"
+    # }
     time = {
       source  = "hashicorp/time"
       version = ">= 0.6"
     }
-
+    utils = {
+      source  = "cloudposse/utils"
+      version = ">= 0.12.0"
+    }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -10,18 +10,6 @@ terraform {
       source  = "hashicorp/helm"
       version = ">= 1.0"
     }
-    # null = {
-    #   source  = "hashicorp/null"
-    #   version = ">= 2.0"
-    # }
-    # local = {
-    #   source  = "hashicorp/local"
-    #   version = ">= 1.3"
-    # }
-    # kubernetes = {
-    #   source  = "hashicorp/kubernetes"
-    #   version = ">= 1.10"
-    # }
     time = {
       source  = "hashicorp/time"
       version = ">= 0.6"


### PR DESCRIPTION
Changes:
* Add ability to override or add configuration options in default values 
* Delegate Kubernetes namespace creation to helm provider from Kubernetes provider
* Remove fake dependency variable in favor of terraform built-in module dependency
* Bump default chart version to the 1.5.3

Breaking changes:
* Removes fake dependency variable `mod_dependency` in favor of terraform built-in module dependency injection
Signed-off-by: Ondřej Šmalec <ondrej.smalec@lablabs.io>