### PR TITLE
fix(cluster-issuer): add common labels to the http solver resources

### DIFF
--- a/helm/defaultClusterIssuer/templates/clusterIssuerHTTP.yaml
+++ b/helm/defaultClusterIssuer/templates/clusterIssuerHTTP.yaml
@@ -40,6 +40,9 @@ spec:
                   app.kubernetes.io/managed-by: {{ .Release.Service }}
                   app.kubernetes.io/component: "clusterIssuer"
                   helm.sh/chart: {{ include "defaultClusterIssuer.chart" . }}
+                  {{- with $.commonLabels }}
+                  {{- toYaml . | nindent 18 }}
+                  {{- end }}
                   {{- with .clusterIssuerValues.podLabels }}
                   {{- toYaml . | nindent 18 }}
                   {{- end }}
@@ -72,6 +75,9 @@ spec:
                   app.kubernetes.io/managed-by: {{ .Release.Service }}
                   app.kubernetes.io/component: "clusterIssuer"
                   helm.sh/chart: {{ include "defaultClusterIssuer.chart" . }}
+                  {{- with $.commonLabels }}
+                  {{- toYaml . | nindent 18 }}
+                  {{- end }}
                   {{- with .clusterIssuerValues.ingressLabels }}
                   {{- toYaml . | nindent 18 }}
                   {{- end }}

--- a/helm/defaultClusterIssuer/values.yaml
+++ b/helm/defaultClusterIssuer/values.yaml
@@ -1,6 +1,8 @@
 nameOverride: ""
 fullnameOverride: ""
 
+commonLabels: {}
+
 route53:
   default:
     acme:


### PR DESCRIPTION
# Description

additional fix adding `common labels` to all resources created by http solver in each instance of cluster issuer, which supports http challenge
## Type of change

- [x] A bug fix (PR prefix `fix`)
- [ ] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?

set `commonLabels` variable in the cluster issuer chart ->  value of this variable was added to the pod and ingress annotations
