### PR TITLE
feat(values) adjust rbac value

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ No modules.
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Variable indicating whether deployment is enabled | `bool` | `true` | no |
 | <a name="input_helm_atomic"></a> [helm\_atomic](#input\_helm\_atomic) | If set, installation process purges chart on fail. The wait flag will be set automatically if atomic is used | `bool` | `false` | no |
 | <a name="input_helm_chart_name"></a> [helm\_chart\_name](#input\_helm\_chart\_name) | Helm chart name to be installed | `string` | `"cert-manager"` | no |
-| <a name="input_helm_chart_version"></a> [helm\_chart\_version](#input\_helm\_chart\_version) | Version of the Helm chart | `string` | `"1.12.1"` | no |
+| <a name="input_helm_chart_version"></a> [helm\_chart\_version](#input\_helm\_chart\_version) | Version of the Helm chart | `string` | `"1.16.0"` | no |
 | <a name="input_helm_cleanup_on_fail"></a> [helm\_cleanup\_on\_fail](#input\_helm\_cleanup\_on\_fail) | Allow deletion of new resources created in this helm upgrade when upgrade fails | `bool` | `false` | no |
 | <a name="input_helm_create_namespace"></a> [helm\_create\_namespace](#input\_helm\_create\_namespace) | Whether to create k8s namespace with name defined by `namespace` | `bool` | `true` | no |
 | <a name="input_helm_dependency_update"></a> [helm\_dependency\_update](#input\_helm\_dependency\_update) | Runs helm dependency update before installing the chart | `bool` | `false` | no |

--- a/values.tf
+++ b/values.tf
@@ -1,8 +1,10 @@
 locals {
   values = yamlencode({
     "installCRDs" : true,
-    "rbac" : {
-      "create" : var.rbac_create
+    "global" : {
+      "rbac" : {
+        "create" : var.rbac_create
+      }
     }
     "serviceAccount" : {
       "create" : var.service_account_create

--- a/variables.tf
+++ b/variables.tf
@@ -22,7 +22,7 @@ variable "helm_chart_name" {
 
 variable "helm_chart_version" {
   type        = string
-  default     = "1.12.1"
+  default     = "1.16.0"
   description = "Version of the Helm chart"
 }
 


### PR DESCRIPTION
# Description

In Cert-Manager was enabled schema validation and rbac was incorrect value. This PR should resolve problem when deploying versions 1.16.0 and above and shouldn't end up with

In Cert-manager [v1.16.0](https://github.com/cert-manager/cert-manager/releases/tag/v1.16.0) new values schema validation is enabled. RBAC is moved to global section. This PR is fixing correct position of RBAC value and should resolve problem when deploying cert-manager 1.16 and above. Otherwise this error can occur:

`Error: values don't meet the specifications of the schema(s) in the following chart(s): cert-manager: - (root): Additional property rbac is not allowed`

## Type of change

- [ ] A bug fix (PR prefix `fix`)
- [x] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?

Source local module instead of remote release
